### PR TITLE
Adjust install script to contain version for gym dependency

### DIFF
--- a/scripts/setup/install_pypkgs.sh
+++ b/scripts/setup/install_pypkgs.sh
@@ -35,7 +35,7 @@ conda install Pillow=5.4.1
 conda install scikit-learn
 
 # Not available in conda, use pip
-pip install gym
+pip install gym==0.13.1
 pip install opencv-python
 pip install atari_py
 pip install gin-config


### PR DESCRIPTION
During the setup of the project I noticed that the current version (0.17.2) of the dependency gym is not compatible with the openai-baseline fork for this repository. Due to this [issue](https://github.com/araffin/rl-baselines-zoo/issues/51).

Thus I adjusted the setup script to install a version for the gym dependency for which the experiment does seem to run. 

